### PR TITLE
Inbox: only update notification badge for Inbox view.

### DIFF
--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -125,7 +125,7 @@ Ext.define('Rambox.store.ServicesList', {
 			,url: 'https://inbox.google.com/?cid=imp'
 			,type: 'email'
 			,manual_notifications: true
-			,js_unread: `let checkUnread=()=>{rambox.updateBadge(document.getElementsByClassName("ss").length)};setInterval(checkUnread,3e3);`
+			,js_unread: `let checkUnread=()=>{if(getComputedStyle(document.getElementsByClassName("sM")[0])["font-weight"] == "bold"){rambox.updateBadge(document.getElementsByClassName("ss").length)}};setInterval(checkUnread,3e3);`
 			,note: 'Please be sure to sign out of Hangouts inside Inbox, as it causes problems. <a href="https://github.com/TheGoddessInari/rambox/wiki/Inbox" target="_blank">Read more...</a>'
 		},
 		{


### PR DESCRIPTION
Currently the unread badges are updated in any view (such as Done,
Snoozed or any folder). These are not unread/new messages and as such
should not count towards the badge.

This patch works around that issue by checking if the current view is
the Inbox view, and not updating the unread count otherwise.

See: https://github.com/ramboxapp/community-edition/issues/1136, https://github.com/ramboxapp/community-edition/pull/1853