### PR TITLE
Enable sandbox for WebViews

### DIFF
--- a/app/ux/WebView.js
+++ b/app/ux/WebView.js
@@ -167,7 +167,7 @@ Ext.define('Rambox.ux.WebView',{
 					,partition: 'persist:' + me.record.get('type') + '_' + me.id.replace('tab_', '')
 					,allowtransparency: 'on'
 					,autosize: 'on'
-					,webpreferences: '' //,nativeWindowOpen=true
+					,webpreferences: 'sandbox: true' //,nativeWindowOpen=true
 					//,disablewebsecurity: 'on' // Disabled because some services (Like Google Drive) dont work with this enabled
 					,userAgent: me.getUserAgent()
 					,preload: './resources/js/rambox-service-api.js'


### PR DESCRIPTION
Since v5.0.0 Electron has enabled the mixed sandbox by default. This means we can sandbox the WebViews, while leaving the main application un-sandboxed.

This works on Linux as long as user namespaces are enabled in the running kernel's configuration (and if they're not you just need to run `# sysctl -w kernel.unprivileged_userns_clone=1`). Tested on Debian 10. Not tested on Windows or MacOS.